### PR TITLE
Fix RSS feed

### DIFF
--- a/app/views/definities/recent.xml.builder
+++ b/app/views/definities/recent.xml.builder
@@ -14,7 +14,7 @@ xml.rss("version" => "2.0", "xmlns:dc" => "http://purl.org/dc/elements/1.1/") do
         xml.guid definition_url(definition.id)
         xml.description do
           xml << format_user_content_for_xml(definition.description)
-          xml << "<> #{format_user_content_for_xml(definition.example)} <>"
+          xml << "![CDATA[ #{format_user_content_for_xml(definition.example)} ]]"
         end
       end
     end

--- a/app/views/definities/recent_changes.xml.builder
+++ b/app/views/definities/recent_changes.xml.builder
@@ -14,7 +14,7 @@ xml.rss("version" => "2.0", "xmlns:dc" => "http://purl.org/dc/elements/1.1/") do
         xml.guid definition_url(definition_version.definition.id)
         xml.description do
           xml << format_user_content_for_xml(definition_version.description)
-          xml << "<> #{format_user_content_for_xml(definition_version.example)} <>"
+          xml << "![CDATA[ #{format_user_content_for_xml(definition_version.example)} ]]"
         end
       end
     end

--- a/app/views/definities/woordvandedag.xml.builder
+++ b/app/views/definities/woordvandedag.xml.builder
@@ -14,7 +14,7 @@ xml.rss("version" => "2.0", "xmlns:dc" => "http://purl.org/dc/elements/1.1/") do
         xml.guid definition_url(wotd.definition)
         xml.description do
           xml << format_user_content_for_xml(wotd.definition.description)
-          xml << "<> #{format_user_content_for_xml(wotd.definition.example)} <>"
+          xml << "![CDATA[ #{format_user_content_for_xml(wotd.definition.example)} ]]"
         end
       end
     end


### PR DESCRIPTION
De huidige RSS feed valideert niet correct (zie o.a. https://www.rssboard.org/rss-validator/ en https://validator.w3.org/feed/), waardoor het in readers zoals b.v. de built-in Thunderbird reader niet kan ingelezen worden. 
Da's spijtig!

Het probleem zit em in de HTML tags dat mee in de description worden opgenomen, en verkeerdelijk worden geinterpreteerd. De oplossing is heel simpel: gebruik maken van `![CDATE[ ... ]]` ipv `<> ... <>`.

