### PR TITLE
Fix CDATA in RSS

### DIFF
--- a/app/views/definities/recent.xml.builder
+++ b/app/views/definities/recent.xml.builder
@@ -13,8 +13,10 @@ xml.rss("version" => "2.0", "xmlns:dc" => "http://purl.org/dc/elements/1.1/") do
         xml.link definition_url(definition.id)
         xml.guid definition_url(definition.id)
         xml.description do
+          xml << "![CDATA["
           xml << format_user_content_for_xml(definition.description)
-          xml << "<> #{format_user_content_for_xml(definition.example)} <>"
+          xml << "#{format_user_content_for_xml(definition.example)}"
+          xml << "]]"
         end
       end
     end

--- a/app/views/definities/recent_changes.xml.builder
+++ b/app/views/definities/recent_changes.xml.builder
@@ -13,8 +13,10 @@ xml.rss("version" => "2.0", "xmlns:dc" => "http://purl.org/dc/elements/1.1/") do
         xml.link definition_url(definition_version.definition.id)
         xml.guid definition_url(definition_version.definition.id)
         xml.description do
+          xml << "![CDATA["
           xml << format_user_content_for_xml(definition_version.description)
-          xml << "<> #{format_user_content_for_xml(definition_version.example)} <>"
+          xml << "#{format_user_content_for_xml(definition_version.example)}"
+          xml << "]]"
         end
       end
     end

--- a/app/views/definities/woordvandedag.xml.builder
+++ b/app/views/definities/woordvandedag.xml.builder
@@ -13,8 +13,10 @@ xml.rss("version" => "2.0", "xmlns:dc" => "http://purl.org/dc/elements/1.1/") do
         xml.link definition_url(wotd.definition)
         xml.guid definition_url(wotd.definition)
         xml.description do
+          xml << "![CDATA["
           xml << format_user_content_for_xml(wotd.definition.description)
-          xml << "<> #{format_user_content_for_xml(wotd.definition.example)} <>"
+          xml << "#{format_user_content_for_xml(wotd.definition.example)}"
+          xml << "]]"
         end
       end
     end


### PR DESCRIPTION
Verderzetting op https://github.com/vlaamswoordenboek/vlaamswoordenboek.be/pull/941, maar heeft ditmaal wel de volledige description in de CDATA. Ik heb wel niet kunnen kijken naar waarom enkel woord van de dag werkt, maar eerlijk gezegd vind ik dat toch de enige interessante. :-)